### PR TITLE
updated main.py & settings.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,9 +8,7 @@ these settings as is, and skip to START OF APPLICATION section below """
 import sys
 sys.dont_write_bytecode = True
 
-# Django specific settings
-import os
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+# setup django environment
 import django
 django.setup()
 

--- a/settings.py
+++ b/settings.py
@@ -1,17 +1,18 @@
-import os
+from pathlib import Path
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+# Build paths inside the project like this: BASE_DIR / 'sub_dir' 
+BASE_DIR = Path(__file__).resolve().parent
 
 # SECURITY WARNING: Modify this secret key if using in production!
 SECRET_KEY = "6few3nci_q_o@l1dlbk81%wcxe!*6r29yu629&d97!hiqat9fa"
 
-DEFAULT_AUTO_FIELD='django.db.models.AutoField'
+# Use BigAutoField for Default Primary Key field type
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+        "NAME": BASE_DIR / 'db.sqlite3',
     }
 }
 


### PR DESCRIPTION
In the `settings.py` I used `pathlib` module which is used by Django currently to get the `BASE_DIR` as it simplifies the concatenation of paths.
```python
# original
BASE_DIR = os.path.dirname(os.path.abspath(__file__))

# I changed it to
BASE_DIR = Path(__file__).resolve().parent
```
I also changed the `DEFAULT_AUTO_FIELD` to use `BigAutoField` instead of just `AutoField` as it is being used by the Django currently.

In the `main.py`, I removed the following lines
```python
# Django specific settings
import os
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
```
as the `DJANGO_SETTINGS_MODULE` is being set by the manage.py in the environ. I think it is redundant.